### PR TITLE
RFC 0001 clarification

### DIFF
--- a/rfcs/0001-node-start.md
+++ b/rfcs/0001-node-start.md
@@ -12,12 +12,9 @@ To support users that have Node.js applications that require no external `node m
 
 Detection will pass if there is a .js file in the application source.
 
-During the build, the buildpack will write the start command `node server.js`. `server.js` was selected as the default because it is the default application name chosen by `npm start` if the user does not specify a start command.
+During the build, the buildpack will write the start command `node server.js`. `server.js` was selected as the default because it is the default application name chosen by `npm start` if the user does not specify a start command. For simplicity, the initial implementation **does not** allow the user to specify a different filename for the start command.
 
 ## Source Material (Optional)
 
 [npm-start docs](https://docs.npmjs.com/cli/start.html)
 
-## Unresolved Questions
-
-Should we support a user's ability to specify an app filename other than `server.js` in our initial implementation?


### PR DESCRIPTION
Explains the decision to use hard-coded filename in the start command, and removes the "Unresolved Questions" section.