### PR TITLE
Requires node_modules when package.json is present

### DIFF
--- a/build.go
+++ b/build.go
@@ -1,6 +1,8 @@
 package nodestart
 
 import (
+	"os"
+
 	"github.com/paketo-buildpacks/packit/v2"
 	"github.com/paketo-buildpacks/packit/v2/scribe"
 )
@@ -9,7 +11,7 @@ func Build(applicationFinder ApplicationFinder, logger scribe.Emitter) packit.Bu
 	return func(context packit.BuildContext) (packit.BuildResult, error) {
 		logger.Title("%s %s", context.BuildpackInfo.Name, context.BuildpackInfo.Version)
 
-		file, err := applicationFinder.Find(context.WorkingDir)
+		file, err := applicationFinder.Find(context.WorkingDir, os.Getenv("BP_LAUNCHPOINT"), os.Getenv("BP_NODE_PROJECT_PATH"))
 		if err != nil {
 			return packit.BuildResult{}, err
 		}

--- a/build_test.go
+++ b/build_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -33,13 +32,13 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		layersDir, err = ioutil.TempDir("", "layers")
+		layersDir, err = os.MkdirTemp("", "layers")
 		Expect(err).NotTo(HaveOccurred())
 
-		cnbDir, err = ioutil.TempDir("", "cnb")
+		cnbDir, err = os.MkdirTemp("", "cnb")
 		Expect(err).NotTo(HaveOccurred())
 
-		workingDir, err = ioutil.TempDir("", "working-dir")
+		workingDir, err = os.MkdirTemp("", "working-dir")
 		Expect(err).NotTo(HaveOccurred())
 
 		applicationFinder = &fakes.ApplicationFinder{}

--- a/detect.go
+++ b/detect.go
@@ -3,54 +3,21 @@ package nodestart
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
-	"strings"
 
 	"github.com/paketo-buildpacks/packit/v2"
+	"github.com/paketo-buildpacks/packit/v2/fs"
 )
 
 //go:generate faux --interface ApplicationFinder --output fakes/application_finder.go
 type ApplicationFinder interface {
-	Find(workingDir string) (string, error)
-}
-
-type launchpointError string
-
-func NewLaunchpointError(launchpoint string) launchpointError {
-	return launchpointError(launchpoint)
-}
-func (s launchpointError) Error() string {
-	return fmt.Sprintf("expected value derived from BP_LAUNCHPOINT [%s] to be an existing file", string(s))
-}
-
-type targetFileError struct {
-	expectedFiles []string
-	projectPath   string
-}
-
-func NewTargetFileError(expectedFiles []string, projectPath string) targetFileError {
-	return targetFileError{
-		expectedFiles: expectedFiles,
-		projectPath:   projectPath,
-	}
-}
-
-func (t targetFileError) Error() string {
-	return fmt.Sprintf("expected one of the following files to be in your application root (%s): %s", t.projectPath, strings.Join(t.expectedFiles, " | "))
+	Find(workingDir, launchpoint, projectPath string) (string, error)
 }
 
 func Detect(applicationFinder ApplicationFinder) packit.DetectFunc {
 	return func(context packit.DetectContext) (packit.DetectResult, error) {
-		_, err := applicationFinder.Find(context.WorkingDir)
-
-		if _, ok := err.(launchpointError); ok {
-			return packit.DetectResult{}, packit.Fail.WithMessage(err.Error())
-		}
-
-		if _, ok := err.(targetFileError); ok {
-			return packit.DetectResult{}, packit.Fail.WithMessage(err.Error())
-		}
-
+		_, err := applicationFinder.Find(context.WorkingDir, os.Getenv("BP_LAUNCHPOINT"), os.Getenv("BP_NODE_PROJECT_PATH"))
 		if err != nil {
 			return packit.DetectResult{}, err
 		}
@@ -62,6 +29,20 @@ func Detect(applicationFinder ApplicationFinder) packit.DetectFunc {
 					"launch": true,
 				},
 			},
+		}
+
+		exists, err := fs.Exists(filepath.Join(context.WorkingDir, os.Getenv("BP_NODE_PROJECT_PATH"), "package.json"))
+		if err != nil {
+			return packit.DetectResult{}, err
+		}
+
+		if exists {
+			requirements = append(requirements, packit.BuildPlanRequirement{
+				Name: "node_modules",
+				Metadata: map[string]interface{}{
+					"launch": true,
+				},
+			})
 		}
 
 		shouldReload, err := checkLiveReloadEnabled()

--- a/fakes/application_finder.go
+++ b/fakes/application_finder.go
@@ -4,26 +4,30 @@ import "sync"
 
 type ApplicationFinder struct {
 	FindCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
-			WorkingDir string
+			WorkingDir  string
+			Launchpoint string
+			ProjectPath string
 		}
 		Returns struct {
 			String string
 			Error  error
 		}
-		Stub func(string) (string, error)
+		Stub func(string, string, string) (string, error)
 	}
 }
 
-func (f *ApplicationFinder) Find(param1 string) (string, error) {
-	f.FindCall.Lock()
-	defer f.FindCall.Unlock()
+func (f *ApplicationFinder) Find(param1 string, param2 string, param3 string) (string, error) {
+	f.FindCall.mutex.Lock()
+	defer f.FindCall.mutex.Unlock()
 	f.FindCall.CallCount++
 	f.FindCall.Receives.WorkingDir = param1
+	f.FindCall.Receives.Launchpoint = param2
+	f.FindCall.Receives.ProjectPath = param3
 	if f.FindCall.Stub != nil {
-		return f.FindCall.Stub(param1)
+		return f.FindCall.Stub(param1, param2, param3)
 	}
 	return f.FindCall.Returns.String, f.FindCall.Returns.Error
 }

--- a/integration.json
+++ b/integration.json
@@ -1,4 +1,5 @@
 {
   "node-engine": "github.com/paketo-buildpacks/node-engine",
+  "npm-install": "github.com/paketo-buildpacks/npm-install",
   "watchexec": "github.com/paketo-buildpacks/watchexec"
 }

--- a/integration/launchpoint_test.go
+++ b/integration/launchpoint_test.go
@@ -58,8 +58,8 @@ func testLaunchpoint(t *testing.T, context spec.G, it spec.S) {
 			image, logs, err = pack.Build.
 				WithPullPolicy("never").
 				WithBuildpacks(
-					nodeEngineBuildpack,
-					buildpack,
+					settings.Buildpacks.NodeEngine.Online,
+					settings.Buildpacks.NodeStart.Online,
 				).
 				WithEnv(map[string]string{"BP_LAUNCHPOINT": "./src/launchpoint.js"}).
 				Execute(name, source)
@@ -75,7 +75,7 @@ func testLaunchpoint(t *testing.T, context spec.G, it spec.S) {
 			Eventually(container).Should(Serve(ContainSubstring("hello world")).OnPort(8080))
 
 			Expect(logs).To(ContainLines(
-				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
+				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
 				"  Assigning launch processes:",
 				"    web (default): node src/launchpoint.js",
 			))

--- a/integration/node_modules_test.go
+++ b/integration/node_modules_test.go
@@ -1,0 +1,72 @@
+package integration_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paketo-buildpacks/occam"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/occam/matchers"
+)
+
+func testNodeModules(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect     = NewWithT(t).Expect
+		Eventually = NewWithT(t).Eventually
+
+		pack   occam.Pack
+		docker occam.Docker
+
+		image     occam.Image
+		container occam.Container
+
+		name   string
+		source string
+	)
+
+	it.Before(func() {
+		pack = occam.NewPack().WithVerbose().WithNoColor()
+		docker = occam.NewDocker()
+
+		var err error
+		name, err = occam.RandomName()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	it.After(func() {
+		Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
+		Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+		Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
+		Expect(os.RemoveAll(source)).To(Succeed())
+	})
+
+	it("builds and runs successfully", func() {
+		var err error
+		source, err = occam.Source(filepath.Join("testdata", "with_package_json"))
+		Expect(err).NotTo(HaveOccurred())
+
+		var logs fmt.Stringer
+		image, logs, err = pack.Build.
+			WithPullPolicy("never").
+			WithBuildpacks(
+				settings.Buildpacks.NodeEngine.Online,
+				settings.Buildpacks.NPMInstall.Online,
+				settings.Buildpacks.NodeStart.Online,
+			).
+			Execute(name, source)
+		Expect(err).ToNot(HaveOccurred(), logs.String)
+
+		container, err = docker.Container.Run.
+			WithEnv(map[string]string{"PORT": "8080"}).
+			WithPublish("8080").
+			WithPublishAll().
+			Execute(image.ID)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(container).Should(Serve(ContainSubstring("hello world")))
+	})
+}

--- a/integration/project_path_test.go
+++ b/integration/project_path_test.go
@@ -58,8 +58,8 @@ func testProjectPath(t *testing.T, context spec.G, it spec.S) {
 			image, logs, err = pack.Build.
 				WithPullPolicy("never").
 				WithBuildpacks(
-					nodeEngineBuildpack,
-					buildpack,
+					settings.Buildpacks.NodeEngine.Online,
+					settings.Buildpacks.NodeStart.Online,
 				).
 				WithEnv(map[string]string{"BP_NODE_PROJECT_PATH": "./src"}).
 				Execute(name, source)
@@ -75,7 +75,7 @@ func testProjectPath(t *testing.T, context spec.G, it spec.S) {
 			Eventually(container).Should(Serve(ContainSubstring("hello world")).OnPort(8080))
 
 			Expect(logs).To(ContainLines(
-				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
+				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
 				"  Assigning launch processes:",
 				"    web (default): node src/server.js",
 			))

--- a/integration/testdata/with_package_json/package.json
+++ b/integration/testdata/with_package_json/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "simple_app",
+  "version": "0.0.0",
+  "description": "some app",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "",
+  "dependencies": {
+    "leftpad": "~0.0.1"
+  },
+  "devDependencies": {
+    "spellchecker-cli": "^4.8.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": ""
+  },
+  "engines": {
+    "node": "~16"
+  }
+}

--- a/integration/testdata/with_package_json/server.js
+++ b/integration/testdata/with_package_json/server.js
@@ -1,0 +1,17 @@
+const http = require('http')
+const port = process.env.PORT || 8080
+const leftpad = require('leftpad');
+
+const requestHandler = (request, response) => {
+    response.end("hello world")
+}
+
+const server = http.createServer(requestHandler)
+
+server.listen(port, (err) => {
+    if (err) {
+        return console.log('something bad happened', err)
+    }
+
+    console.log(`server is listening on ${port}`)
+})

--- a/node_application_finder_test.go
+++ b/node_application_finder_test.go
@@ -1,12 +1,12 @@
 package nodestart_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
 	nodestart "github.com/paketo-buildpacks/node-start"
+	"github.com/paketo-buildpacks/packit/v2"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
@@ -22,105 +22,78 @@ func testNodeApplicationFinder(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		workingDir, err = ioutil.TempDir("", "working-dir")
+		workingDir, err = os.MkdirTemp("", "working-dir")
 		Expect(err).NotTo(HaveOccurred())
 
-		nodeApplicationFinder = nodestart.NewNodeApplicationFinder()
+		Expect(os.WriteFile(filepath.Join(workingDir, "server.js"), nil, 0600)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(workingDir, "app.js"), nil, 0600)).To(Succeed())
 	})
 
 	it.After(func() {
 		Expect(os.RemoveAll(workingDir)).To(Succeed())
 	})
 
-	context("when BP_LAUNCHPOINT is set", func() {
+	it("finds the application entrypoint", func() {
+		file, err := nodeApplicationFinder.Find(workingDir, "", "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(file).To(Equal(filepath.Join("server.js")))
+	})
+
+	context("when there is a launchpoint", func() {
 		it.Before(func() {
-			Expect(os.Setenv("BP_LAUNCHPOINT", "./src/launchpoint.js")).To(Succeed())
+			Expect(os.Mkdir(filepath.Join(workingDir, "src"), os.ModePerm)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "src", "launchpoint.js"), nil, 0600)).To(Succeed())
 		})
 
 		it.After(func() {
-			os.Unsetenv("BP_LAUNCHPOINT")
+			Expect(os.RemoveAll(filepath.Join(workingDir, "src"))).To(Succeed())
 		})
 
-		context("file specified by LAUNCHPOINT exists", func() {
-			it.Before(func() {
-				Expect(os.Mkdir(filepath.Join(workingDir, "src"), os.ModePerm)).To(Succeed())
-				Expect(ioutil.WriteFile(filepath.Join(workingDir, "src", "launchpoint.js"), nil, 0644)).To(Succeed())
-
-			})
-
-			it.After(func() {
-				Expect(os.RemoveAll(filepath.Join(workingDir, "src"))).To(Succeed())
-			})
-
+		context("when the launchpoint file exists", func() {
 			it("returns the highest priority file", func() {
-				file, err := nodeApplicationFinder.Find(workingDir)
+				file, err := nodeApplicationFinder.Find(workingDir, "./src/launchpoint.js", "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(file).To(Equal(filepath.Join("src", "launchpoint.js")))
 			})
 		})
 
-		context("file specified by LAUNCHPOINT DOES NOT exist", func() {
+		context("when the launchpoint file does not exist", func() {
 			it("returns the empty string and no error", func() {
-				file, err := nodeApplicationFinder.Find(workingDir)
-				Expect(err).To(MatchError(ContainSubstring("expected value derived from BP_LAUNCHPOINT [./src/launchpoint.js] to be an existing file")))
+				file, err := nodeApplicationFinder.Find(workingDir, "./no-such-file.js", "")
+				Expect(err).To(MatchError(ContainSubstring("expected value derived from BP_LAUNCHPOINT [./no-such-file.js] to be an existing file")))
 				Expect(file).To(Equal(""))
 			})
 		})
-	}, spec.Sequential())
+	})
 
-	context("BP_LAUNCHPOINT is NOT set && BP_NODE_PROJECT_PATH is set", func() {
+	context("when there is a project path", func() {
 		it.Before(func() {
 			Expect(os.Mkdir(filepath.Join(workingDir, "frontend"), os.ModePerm)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(workingDir, "frontend", "server.js"), nil, 0644)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(workingDir, "frontend", "app.js"), nil, 0644)).To(Succeed())
-			Expect(os.Setenv("BP_NODE_PROJECT_PATH", "frontend")).To(Succeed())
-		})
-
-		it.After(func() {
-			os.Unsetenv("BP_NODE_PROJECT_PATH")
+			Expect(os.WriteFile(filepath.Join(workingDir, "frontend", "server.js"), nil, 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "frontend", "app.js"), nil, 0600)).To(Succeed())
 		})
 
 		it("returns the highest priority file", func() {
-			file, err := nodeApplicationFinder.Find(workingDir)
+			file, err := nodeApplicationFinder.Find(workingDir, "", "frontend")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(file).To(Equal(filepath.Join("frontend", "server.js")))
 		})
+	})
 
-	}, spec.Sequential())
-
-	context("BP_LAUNCHPOINT is NOT set && when BP_NODE_PROJECT_PATH is NOT set ", func() {
+	context("when no application can be found", func() {
 		it.Before(func() {
-			Expect(ioutil.WriteFile(filepath.Join(workingDir, "server.js"), nil, 0644)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(workingDir, "app.js"), nil, 0644)).To(Succeed())
+			Expect(os.RemoveAll(workingDir)).To(Succeed())
+			Expect(os.MkdirAll(workingDir, os.ModePerm)).To(Succeed())
 		})
 
-		it("returns the highest priority file", func() {
-			file, err := nodeApplicationFinder.Find(workingDir)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(file).To(Equal(filepath.Join("server.js")))
+		it("returns a packit failure", func() {
+			_, err := nodeApplicationFinder.Find(workingDir, "", "")
+			Expect(err).To(MatchError(packit.Fail.WithMessage("could not find app in %s: expected one of server.js | app.js | main.js | index.js", workingDir)))
 		})
-
-	}, spec.Sequential())
+	})
 
 	context("failure cases", func() {
-		context("when os.Stat() cannot be performed on the working dir", func() {
-			it.Before(func() {
-				os.Setenv("BP_LAUNCHPOINT", "something.js")
-				Expect(os.Chmod(workingDir, 0000)).To(Succeed())
-			})
-
-			it.After(func() {
-				os.Unsetenv("BP_LAUNCHPOINT")
-				Expect(os.Chmod(workingDir, os.ModePerm)).To(Succeed())
-			})
-
-			it("fails with helpful error", func() {
-				_, err := nodeApplicationFinder.Find(workingDir)
-				Expect(err).To(MatchError(ContainSubstring("permission denied")))
-			})
-		}, spec.Sequential())
-
-		context("when os.Stat() cannot be performed on the working dir", func() {
+		context("when the launchpoint cannot be stat'd", func() {
 			it.Before(func() {
 				Expect(os.Chmod(workingDir, 0000)).To(Succeed())
 			})
@@ -130,9 +103,24 @@ func testNodeApplicationFinder(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("fails with helpful error", func() {
-				_, err := nodeApplicationFinder.Find(workingDir)
+				_, err := nodeApplicationFinder.Find(workingDir, "something.js", "")
 				Expect(err).To(MatchError(ContainSubstring("permission denied")))
 			})
-		}, spec.Sequential())
+		})
+
+		context("when the working dir cannot be stat'd", func() {
+			it.Before(func() {
+				Expect(os.Chmod(workingDir, 0000)).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Chmod(workingDir, os.ModePerm)).To(Succeed())
+			})
+
+			it("fails with helpful error", func() {
+				_, err := nodeApplicationFinder.Find(workingDir, "", "")
+				Expect(err).To(MatchError(ContainSubstring("permission denied")))
+			})
+		})
 	})
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This addition to the detect phase will have the buildpack require `node_modules` if there is a `package.json` present in project path. The idea here is to enable cases where users don't explicitly want to specify their start command via the `scripts.start` field in a `package.json`, and instead are relying on the existing `node-start` or `procfile` buildpacks to set their command correctly. In these cases, the user intends for `node_modules` to be installed and made available for launch, but they are not being terribly explicit about it.

## Use Cases
<!-- An explanation of the use cases your change enables -->
This was previously supported before https://github.com/paketo-buildpacks/npm-start/pull/179, and that same overall behavior within the buildpack can be restored with this change.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
