### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Node Start Cloud Native Buildpack
+# Paketo Buildpack for Node Start
 ## `gcr.io/paketo-buildpacks/node-start`
 
 The Paketo Node Start CNB sets the start command for a given node application.

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.7"
 [buildpack]
   homepage = "https://github.com/paketo-buildpacks/node-start"
   id = "paketo-buildpacks/node-start"
-  name = "Paketo Node Start Buildpack"
+  name = "Paketo Buildpack for Node Start"
 
   [[buildpack.licenses]]
     type = "Apache-2.0"


### PR DESCRIPTION
Renames 'Paketo Node Start Buildpack' to 'Paketo Buildpack for Node Start'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
