### PR TITLE
Use `libreload-packit` to handle live reload

### DIFF
--- a/fakes/reloader.go
+++ b/fakes/reloader.go
@@ -1,0 +1,54 @@
+package fakes
+
+import (
+	"sync"
+
+	"github.com/paketo-buildpacks/libreload-packit"
+	"github.com/paketo-buildpacks/packit/v2"
+)
+
+type Reloader struct {
+	ShouldEnableLiveReloadCall struct {
+		mutex     sync.Mutex
+		CallCount int
+		Returns   struct {
+			Bool  bool
+			Error error
+		}
+		Stub func() (bool, error)
+	}
+	TransformReloadableProcessesCall struct {
+		mutex     sync.Mutex
+		CallCount int
+		Receives  struct {
+			OriginalProcess packit.Process
+			Spec            libreload.ReloadableProcessSpec
+		}
+		Returns struct {
+			NonReloadable packit.Process
+			Reloadable    packit.Process
+		}
+		Stub func(packit.Process, libreload.ReloadableProcessSpec) (packit.Process, packit.Process)
+	}
+}
+
+func (f *Reloader) ShouldEnableLiveReload() (bool, error) {
+	f.ShouldEnableLiveReloadCall.mutex.Lock()
+	defer f.ShouldEnableLiveReloadCall.mutex.Unlock()
+	f.ShouldEnableLiveReloadCall.CallCount++
+	if f.ShouldEnableLiveReloadCall.Stub != nil {
+		return f.ShouldEnableLiveReloadCall.Stub()
+	}
+	return f.ShouldEnableLiveReloadCall.Returns.Bool, f.ShouldEnableLiveReloadCall.Returns.Error
+}
+func (f *Reloader) TransformReloadableProcesses(param1 packit.Process, param2 libreload.ReloadableProcessSpec) (packit.Process, packit.Process) {
+	f.TransformReloadableProcessesCall.mutex.Lock()
+	defer f.TransformReloadableProcessesCall.mutex.Unlock()
+	f.TransformReloadableProcessesCall.CallCount++
+	f.TransformReloadableProcessesCall.Receives.OriginalProcess = param1
+	f.TransformReloadableProcessesCall.Receives.Spec = param2
+	if f.TransformReloadableProcessesCall.Stub != nil {
+		return f.TransformReloadableProcessesCall.Stub(param1, param2)
+	}
+	return f.TransformReloadableProcessesCall.Returns.NonReloadable, f.TransformReloadableProcessesCall.Returns.Reloadable
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/BurntSushi/toml v1.2.0
 	github.com/onsi/gomega v1.20.2
+	github.com/paketo-buildpacks/libreload-packit v0.0.1
 	github.com/paketo-buildpacks/occam v0.13.2
 	github.com/paketo-buildpacks/packit/v2 v2.5.1
 	github.com/sclevine/spec v1.4.0
@@ -37,7 +38,7 @@ require (
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.3-0.20220114050600-8b9d41f48198 // indirect
-	github.com/opencontainers/runc v1.1.3 // indirect
+	github.com/opencontainers/runc v1.1.4 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1748,8 +1748,9 @@ github.com/opencontainers/runc v1.0.0-rc93/go.mod h1:3NOsor4w32B2tC0Zbl8Knk4Wg84
 github.com/opencontainers/runc v1.0.2/go.mod h1:aTaHFFwQXuA71CiyxOdFFIorAoemI04suvGRQFzWTD0=
 github.com/opencontainers/runc v1.1.0/go.mod h1:Tj1hFw6eFWp/o33uxGf5yF2BX5yz2Z6iptFpuvbbKqc=
 github.com/opencontainers/runc v1.1.2/go.mod h1:Tj1hFw6eFWp/o33uxGf5yF2BX5yz2Z6iptFpuvbbKqc=
-github.com/opencontainers/runc v1.1.3 h1:vIXrkId+0/J2Ymu2m7VjGvbSlAId9XNRPhn2p4b+d8w=
 github.com/opencontainers/runc v1.1.3/go.mod h1:1J5XiS+vdZ3wCyZybsuxXZWGrgSr8fFJHLXuG2PsnNg=
+github.com/opencontainers/runc v1.1.4 h1:nRCz/8sKg6K6jgYAFLDlXzPeITBZJyX28DBVhWD+5dg=
+github.com/opencontainers/runc v1.1.4/go.mod h1:1J5XiS+vdZ3wCyZybsuxXZWGrgSr8fFJHLXuG2PsnNg=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.2-0.20190207185410-29686dbc5559/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
@@ -1777,6 +1778,8 @@ github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
+github.com/paketo-buildpacks/libreload-packit v0.0.1 h1:K1HhNAqBSzRpefwGOcvdchZwyeNTgNJL9SC7V4paYt8=
+github.com/paketo-buildpacks/libreload-packit v0.0.1/go.mod h1:ZWE3U94Z18yJk8Pc1mP852l9phQsrsZ+An2U98g0rWw=
 github.com/paketo-buildpacks/occam v0.13.2 h1:4hgDCVx4iHSfk3qDpaFzja94TOJ0tOJ6hOLsrHuUAhw=
 github.com/paketo-buildpacks/occam v0.13.2/go.mod h1:/kuPXK3OXdTmVbZrd6OWmC4/dwrmus6l+MTwhcDbD5A=
 github.com/paketo-buildpacks/packit/v2 v2.1.0/go.mod h1:Ud1X7f9O6e4eGPZlY3pj0jnSa9oDK2L/ghvjmarTLSA=

--- a/run/main.go
+++ b/run/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 
+	"github.com/paketo-buildpacks/libreload-packit/watchexec"
 	nodestart "github.com/paketo-buildpacks/node-start"
 	"github.com/paketo-buildpacks/packit/v2"
 	"github.com/paketo-buildpacks/packit/v2/scribe"
@@ -11,12 +12,15 @@ import (
 func main() {
 	nodeApplicationFinder := nodestart.NewNodeApplicationFinder()
 	logger := scribe.NewEmitter(os.Stdout).WithLevel(os.Getenv("BP_LOG_LEVEL"))
-	
+
+	reloader := watchexec.NewWatchexecReloader()
+
 	packit.Run(
-		nodestart.Detect(nodeApplicationFinder),
+		nodestart.Detect(nodeApplicationFinder, reloader),
 		nodestart.Build(
 			nodeApplicationFinder,
 			logger,
+			reloader,
 		),
 	)
 }


### PR DESCRIPTION
Use `libreload-packit` to handle live reload.

Blocked on #269 which is why this diff is so large.