### PR TITLE
Bump go.mod version to v2

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/paketo-buildpacks/libreload-packit"
-	nodestart "github.com/paketo-buildpacks/node-start"
-	"github.com/paketo-buildpacks/node-start/fakes"
+	nodestart "github.com/paketo-buildpacks/node-start/v2"
+	"github.com/paketo-buildpacks/node-start/v2/fakes"
 	"github.com/paketo-buildpacks/packit/v2"
 	"github.com/paketo-buildpacks/packit/v2/scribe"
 	"github.com/sclevine/spec"

--- a/detect_test.go
+++ b/detect_test.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	nodestart "github.com/paketo-buildpacks/node-start"
-	"github.com/paketo-buildpacks/node-start/fakes"
+	nodestart "github.com/paketo-buildpacks/node-start/v2"
+	"github.com/paketo-buildpacks/node-start/v2/fakes"
 	"github.com/paketo-buildpacks/packit/v2"
 	"github.com/sclevine/spec"
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/paketo-buildpacks/node-start
+module github.com/paketo-buildpacks/node-start/v2
 
 go 1.22.6
 

--- a/run/main.go
+++ b/run/main.go
@@ -4,7 +4,7 @@ import (
 	"os"
 
 	"github.com/paketo-buildpacks/libreload-packit/watchexec"
-	nodestart "github.com/paketo-buildpacks/node-start"
+	nodestart "github.com/paketo-buildpacks/node-start/v2"
 	"github.com/paketo-buildpacks/packit/v2"
 	"github.com/paketo-buildpacks/packit/v2/scribe"
 )


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

To reflect the actual major version and follow the official recommendation regarding `go.mod` versioning

## Use Cases
<!-- An explanation of the use cases your change enables -->

https://go.dev/doc/modules/version-numbers

> A major version update to a number higher than v1 will also have a new module path. That’s because the module path will have the major version number appended, as in the following example:
> 
> > module example.com/mymodule/v2 v2.0.0
>
> A major version update makes this a new module with a separate history from the module’s previous version. If you’re developing modules to publish for others, see “Publishing breaking API changes” in [Module release and versioning workflow](https://go.dev/doc/modules/release-workflow).

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
