### PR TITLE
feat: add support for mjs and cjs files

### DIFF
--- a/detect_test.go
+++ b/detect_test.go
@@ -86,6 +86,31 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		})
 	}, spec.Sequential())
 
+	context("sniff test of when an application is detected in the working dir and does not have a js extension", func() {
+		it.Before(func() {
+			Expect(os.MkdirAll(filepath.Join(workingDir, "src"), os.ModePerm)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "server.mjs"), nil, 0600)).To(Succeed())
+		})
+
+		it("detects", func() {
+			result, err := detect(packit.DetectContext{
+				WorkingDir: workingDir,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Plan).To(Equal(packit.BuildPlan{
+				Requires: []packit.BuildPlanRequirement{
+					{
+						Name: "node",
+						Metadata: map[string]interface{}{
+							"launch": true,
+						},
+					},
+				},
+			}))
+		})
+
+	})
+
 	context("when a package.json is detected in the working dir", func() {
 		it.Before(func() {
 			t.Setenv("BP_NODE_PROJECT_PATH", "./src")
@@ -122,7 +147,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				_, err := detect(packit.DetectContext{
 					WorkingDir: workingDir,
 				})
-				Expect(err).To(MatchError(fmt.Errorf("could not find app in %s: expected one of server.js | app.js | main.js | index.js", workingDir)))
+				Expect(err).To(MatchError(fmt.Errorf("could not find app in %s: expected one of server.js | server.cjs | server.mjs | app.js | app.cjs | app.mjs | main.js | main.cjs | main.mjs | index.js | index.cjs | index.mjs", workingDir)))
 			})
 		})
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 require (
 	github.com/BurntSushi/toml v1.4.0
 	github.com/onsi/gomega v1.34.1
-	github.com/paketo-buildpacks/libnodejs v0.2.0
+	github.com/paketo-buildpacks/libnodejs v0.3.0
 	github.com/paketo-buildpacks/libreload-packit v0.0.1
 	github.com/paketo-buildpacks/occam v0.18.7
 	github.com/paketo-buildpacks/packit/v2 v2.14.2

--- a/go.sum
+++ b/go.sum
@@ -2556,6 +2556,8 @@ github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/paketo-buildpacks/libnodejs v0.2.0 h1:y7G6BQIeeMUnIlzREiAipQlAcaXJ82VMPldkTTiv9o4=
 github.com/paketo-buildpacks/libnodejs v0.2.0/go.mod h1:JLs6tu5TD6la8p1IKo3UYO1C93/ywGesa74FpM82wPw=
+github.com/paketo-buildpacks/libnodejs v0.3.0 h1:vh2fDuUt/XPPy0ENY3mmRHlb127wVD8d782liVKa9WM=
+github.com/paketo-buildpacks/libnodejs v0.3.0/go.mod h1:V8bTCbjjpthcdrDK2g2KL7c0mHQeZJAfN+hQtPpmGuQ=
 github.com/paketo-buildpacks/libreload-packit v0.0.1 h1:K1HhNAqBSzRpefwGOcvdchZwyeNTgNJL9SC7V4paYt8=
 github.com/paketo-buildpacks/libreload-packit v0.0.1/go.mod h1:ZWE3U94Z18yJk8Pc1mP852l9phQsrsZ+An2U98g0rWw=
 github.com/paketo-buildpacks/occam v0.18.7 h1:L5tl/JnzhSKecJ78ggR4SBz9AHqoVKCBJ0EoT8t6y84=


### PR DESCRIPTION
Fixes: https://github.com/paketo-buildpacks/node-start/issues/225

- add support for mjs and cjs files when looking for applications

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Adds support for mjs and cjs files in addition to js files when looking for node.js applications.

See: https://github.com/paketo-buildpacks/node-start/issues/225

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
