### PR TITLE
Introduce BP_VERIFY_LAUNCHPOINT to enable generated files

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ start command that is not included in the above set.
 e.g. If `BP_LAUNCHPOINT=./src/launchpoint.js`, the buildpack will verify that
 the file exists and then set the start command using that file `node src/launchpoint.js`
 
+## BP_VERIFY_LAUNCHPOINT
+
+The `BP_VERIFY_LAUNCHPOINT` environment variable may be used to specify the file for the
+start command that is generated and may not exist yet.
+
+e.g. If `BP_LAUNCHPOINT=./gen/launchpoint.js` and If `BP_VERIFY_LAUNCHPOINT=false`, the buildpack will not verify that
+the file exists and then set the start command using that file `node gen/launchpoint.js`
+
 ## Enabling reloadable process types
 
 You can configure this buildpack to wrap the entrypoint process of your app


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->
needed: https://github.com/paketo-buildpacks/libnodejs/pull/37
fixes: https://github.com/paketo-buildpacks/node-start/issues/588 

## Summary
<!-- A short explanation of the proposed change -->

The env variable `BP_VERIFY_LAUNCHPOINT` can be used to not check that the file to launch exists.

## Use Cases
<!-- An explanation of the use cases your change enables -->

If the file that should be launched is generated.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
