### PR TITLE
Adding ubi9 buildpackless builder on integration tests

### DIFF
--- a/integration.json
+++ b/integration.json
@@ -1,7 +1,8 @@
 {
   "builders": [
-    "paketobuildpacks/builder-jammy-buildpackless-base",
-    "index.docker.io/paketobuildpacks/builder-ubi8-buildpackless-base:latest"
+    "paketobuildpacks/ubi-9-builder-buildpackless",
+    "paketobuildpacks/builder-ubi8-buildpackless-base",
+    "paketobuildpacks/builder-jammy-buildpackless-base"
   ],
   "ubi-nodejs-extension": "github.com/paketo-buildpacks/ubi-nodejs-extension",
   "node-engine": "github.com/paketo-buildpacks/node-engine",

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -81,7 +81,7 @@ func TestIntegration(t *testing.T) {
 	builder, err := pack.Builder.Inspect.Execute()
 	Expect(err).NotTo(HaveOccurred())
 
-	if builder.BuilderName == "index.docker.io/paketobuildpacks/builder-ubi8-buildpackless-base:latest" {
+	if builder.BuilderName == "paketobuildpacks/builder-ubi8-buildpackless-base" || builder.BuilderName == "paketobuildpacks/ubi-9-builder-buildpackless" {
 		settings.Extensions.UbiNodejsExtension.Online, err = buildpackStore.Get.
 			Execute(settings.Config.UbiNodejsExtension)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Merge After
* https://github.com/paketo-buildpacks/ubi-nodejs-extension/pull/375

## Summary
<!-- A short explanation of the proposed change -->
This PR Adds ubi9 buildpackeless builder on integration tests

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
