### PR TITLE
Allowing tini to run Node.js applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Paketo Buildpack for Node Start
+
 ## `docker.io/paketobuildpacks/node-start`
 
 The Paketo Node Start CNB sets the start command for a given node application.
-The buildpack will detect when a valid javascript file is present within the 
+The buildpack will detect when a valid javascript file is present within the
 application source code directory (see [Application Detection](#application-detection).
 
 ## Integration
@@ -20,6 +21,7 @@ $ ./scripts/package.sh --version <version-number>
 ```
 
 This will create a `build/buildpackage.cnb` file which you can use to build your app as follows:
+
 ```shell
 pack build <app-name> \
   --path <path-to-app> \
@@ -33,8 +35,17 @@ You can add signal handlers in your app to support graceful shutdown and
 program interrupts. This buildpack runs the node server as the init process,
 and thus it ignores any signal with the default action. As a result, the
 process will not terminate on `SIGINT` or `SIGTERM` unless it is coded to do
-so. You can also use docker's `--init` flag to wrap your node process with an
-init system that will properly handle signals.
+so.
+
+To use [tini](https://github.com/krallin/tini) instead, set
+`BP_LAUNCH_WITH_TINI=true` at build time. The tini buildpack must be available
+in the builder order before this buildpack; otherwise detection fails. The
+launch process becomes `tini -g -- node <file>`, where `<file>` is the
+application file discovered by default or set via `BP_LAUNCHPOINT`.
+
+For example, with `BP_LAUNCHPOINT=./src/launchpoint.js` and
+`BP_LAUNCH_WITH_TINI=true`, the launch process is
+`tini -g -- node src/launchpoint.js`.
 
 ## Specifying a project path
 
@@ -47,6 +58,7 @@ This could be useful if your app is a part of a monorepo.
 ## Application Detection
 
 This buildpack searches your application root for the following files:
+
 1. `server.[c|m]js`
 1. `app.[c|m]js`
 1. `main.[c|m]js`
@@ -61,7 +73,11 @@ The `BP_LAUNCHPOINT` environment variable may be used to specify a file for the
 start command that is not included in the above set.
 
 e.g. If `BP_LAUNCHPOINT=./src/launchpoint.js`, the buildpack will verify that
-the file exists and then set the start command using that file `node src/launchpoint.js`
+the file exists and then set the start command using that file `node src/launchpoint.js`.
+
+`BP_LAUNCHPOINT` and `BP_LAUNCH_WITH_TINI` can be used together. `BP_LAUNCHPOINT`
+selects which file to run; `BP_LAUNCH_WITH_TINI` wraps that command with tini
+(for example `tini -g -- node src/launchpoint.js`).
 
 ## BP_VERIFY_LAUNCHPOINT
 
@@ -83,16 +99,18 @@ Set the environment variable `BP_LIVE_RELOAD_ENABLED=true` at build time to enab
 ```shell
 pack build my-app \
   --env BP_LIVE_RELOAD_ENABLED=true
-````
+```
 
 ## Run Tests
 
 To run all unit tests, run:
+
 ```shell
 ./scripts/unit.sh
 ```
 
 To run all integration tests, run:
+
 ```shell
 /scripts/integration.sh
 ```

--- a/build.go
+++ b/build.go
@@ -16,12 +16,30 @@ func Build(logger scribe.Emitter, reloader Reloader) packit.BuildFunc {
 			return packit.BuildResult{}, err
 		}
 
-		originalProcess := packit.Process{
-			Type:    "web",
-			Command: "node",
-			Args:    []string{file},
-			Default: true,
-			Direct:  true,
+		var originalProcess packit.Process
+
+		enableTini, err := shouldEnableTini()
+		if err != nil {
+			return packit.BuildResult{}, err
+		}
+
+		if enableTini {
+			originalProcess = packit.Process{
+				Type:    "web",
+				Command: Tini,
+				Args:    []string{"-g", "--", "node", file},
+				Default: true,
+				Direct:  true,
+			}
+			logger.Process("Using tini for process launching")
+		} else {
+			originalProcess = packit.Process{
+				Type:    "web",
+				Command: "node",
+				Args:    []string{file},
+				Default: true,
+				Direct:  true,
+			}
 		}
 
 		var processes []packit.Process

--- a/build_test.go
+++ b/build_test.go
@@ -145,6 +145,66 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		})
 	})
 
+	context("when BP_LAUNCH_WITH_TINI is true", func() {
+		it.Before(func() {
+			t.Setenv("BP_LAUNCH_WITH_TINI", "true")
+		})
+
+		it("uses tini to launch the node process", func() {
+			result, err := build(buildContext)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result.Launch.Processes).To(Equal([]packit.Process{
+				{
+					Type:    "web",
+					Command: "tini",
+					Args:    []string{"-g", "--", "node", "server.js"},
+					Default: true,
+					Direct:  true,
+				},
+			}))
+
+			Expect(buffer.String()).To(ContainSubstring("Using tini for process launching"))
+			Expect(buffer.String()).To(ContainSubstring("Assigning launch processes"))
+		})
+
+		context("when BP_LAUNCHPOINT is set", func() {
+			it.Before(func() {
+				Expect(os.MkdirAll(filepath.Join(workingDir, "src"), os.ModePerm)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(workingDir, "src", "launchpoint.js"), nil, 0600)).To(Succeed())
+				t.Setenv("BP_LAUNCHPOINT", "./src/launchpoint.js")
+			})
+
+			it("uses tini to launch the launchpoint file", func() {
+				result, err := build(buildContext)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(result.Launch.Processes).To(Equal([]packit.Process{
+					{
+						Type:    "web",
+						Command: "tini",
+						Args:    []string{"-g", "--", "node", "src/launchpoint.js"},
+						Default: true,
+						Direct:  true,
+					},
+				}))
+
+				Expect(buffer.String()).To(ContainSubstring("Using tini for process launching"))
+			})
+		})
+	})
+
+	context("when BP_LAUNCH_WITH_TINI is malformed", func() {
+		it.Before(func() {
+			t.Setenv("BP_LAUNCH_WITH_TINI", "not-a-bool")
+		})
+
+		it("returns an error", func() {
+			_, err := build(buildContext)
+			Expect(err).To(MatchError(ContainSubstring("failed to parse BP_LAUNCH_WITH_TINI value not-a-bool")))
+		})
+	})
+
 	context("when live reload is enabled", func() {
 		it.Before(func() {
 			reloader.ShouldEnableLiveReloadCall.Returns.Bool = true
@@ -187,6 +247,38 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 			Expect(buffer.String()).To(ContainSubstring("Some Buildpack some-version"))
 			Expect(buffer.String()).To(ContainSubstring("Assigning launch processes"))
+		})
+
+		context("when BP_LAUNCH_WITH_TINI is also true", func() {
+			it.Before(func() {
+				t.Setenv("BP_LAUNCH_WITH_TINI", "true")
+			})
+
+			it("wraps the tini process with watchexec", func() {
+				result, err := build(buildContext)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(result.Launch.Processes).To(Equal([]packit.Process{
+					{
+						Type:    "web",
+						Command: "Reloadable-Command",
+					},
+					{
+						Type:    "no-reload",
+						Command: "Nonreloadable-Command",
+					},
+				}))
+
+				Expect(reloader.TransformReloadableProcessesCall.Receives.OriginalProcess).To(Equal(packit.Process{
+					Type:    "web",
+					Command: "tini",
+					Args:    []string{"-g", "--", "node", "server.js"},
+					Default: true,
+					Direct:  true,
+				}))
+
+				Expect(buffer.String()).To(ContainSubstring("Using tini for process launching"))
+			})
 		})
 	})
 

--- a/constants.go
+++ b/constants.go
@@ -1,0 +1,6 @@
+package nodestart
+
+const (
+	Tini             = "tini"
+	EnableTiniEnvVar = "BP_LAUNCH_WITH_TINI"
+)

--- a/detect.go
+++ b/detect.go
@@ -1,7 +1,9 @@
 package nodestart
 
 import (
+	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/paketo-buildpacks/libnodejs"
 	"github.com/paketo-buildpacks/libreload-packit"
@@ -45,6 +47,12 @@ func Detect(reloader Reloader) packit.DetectFunc {
 			requirements = append(requirements, newLaunchRequirement("watchexec"))
 		}
 
+		if shouldEnableTini, err := shouldEnableTini(); err != nil {
+			return packit.DetectResult{}, err
+		} else if shouldEnableTini {
+			requirements = append(requirements, newLaunchRequirement(Tini))
+		}
+
 		return packit.DetectResult{
 			Plan: packit.BuildPlan{
 				Requires: requirements,
@@ -60,4 +68,15 @@ func newLaunchRequirement(name string) packit.BuildPlanRequirement {
 			"launch": true,
 		},
 	}
+}
+
+func shouldEnableTini() (bool, error) {
+	if value, found := os.LookupEnv(EnableTiniEnvVar); found {
+		enable, err := strconv.ParseBool(value)
+		if err != nil {
+			return false, fmt.Errorf("failed to parse %s value %s: %w", EnableTiniEnvVar, value, err)
+		}
+		return enable, nil
+	}
+	return false, nil
 }

--- a/detect_test.go
+++ b/detect_test.go
@@ -84,6 +84,46 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				}))
 			})
 		})
+
+		context("when BP_LAUNCH_WITH_TINI is true", func() {
+			it.Before(func() {
+				t.Setenv("BP_LAUNCH_WITH_TINI", "true")
+			})
+
+			it("requires tini at launch time", func() {
+				result, err := detect(packit.DetectContext{
+					WorkingDir: workingDir,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Plan.Requires).To(Equal([]packit.BuildPlanRequirement{
+					{
+						Name: "node",
+						Metadata: map[string]interface{}{
+							"launch": true,
+						},
+					},
+					{
+						Name: "tini",
+						Metadata: map[string]interface{}{
+							"launch": true,
+						},
+					},
+				}))
+			})
+		})
+
+		context("when BP_LAUNCH_WITH_TINI is malformed", func() {
+			it.Before(func() {
+				t.Setenv("BP_LAUNCH_WITH_TINI", "not-a-bool")
+			})
+
+			it("returns an error", func() {
+				_, err := detect(packit.DetectContext{
+					WorkingDir: workingDir,
+				})
+				Expect(err).To(MatchError(ContainSubstring("failed to parse BP_LAUNCH_WITH_TINI value not-a-bool")))
+			})
+		})
 	}, spec.Sequential())
 
 	context("sniff test of when an application is detected in the working dir and does not have a js extension", func() {

--- a/integration.json
+++ b/integration.json
@@ -10,5 +10,6 @@
   "ubi-nodejs-extension": "github.com/paketo-buildpacks/ubi-nodejs-extension",
   "node-engine": "github.com/paketo-buildpacks/node-engine",
   "npm-install": "github.com/paketo-buildpacks/npm-install",
-  "watchexec": "github.com/paketo-buildpacks/watchexec"
+  "watchexec": "github.com/paketo-buildpacks/watchexec",
+  "tini": "github.com/paketo-buildpacks/tini"
 }

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -149,5 +149,46 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				))
 			})
 		})
+
+		context("when BP_LAUNCH_WITH_TINI=true", func() {
+			it("uses tini to launch the node process", func() {
+				var err error
+				source, err = occam.Source(filepath.Join("testdata", "default"))
+				Expect(err).NotTo(HaveOccurred())
+
+				var logs fmt.Stringer
+				image, logs, err = pack.Build.
+					WithPullPolicy(pullPolicy).
+					WithExtensions(
+						settings.Extensions.UbiNodejsExtension.Online,
+					).
+					WithBuildpacks(
+						settings.Buildpacks.NodeEngine.Online,
+						settings.Buildpacks.Tini.Online,
+						settings.Buildpacks.NodeStart.Online,
+					).
+					WithEnv(map[string]string{
+						"BP_LAUNCH_WITH_TINI": "true",
+					}).
+					Execute(name, source)
+				Expect(err).ToNot(HaveOccurred(), logs.String)
+
+				container, err = docker.Container.Run.
+					WithEnv(map[string]string{"PORT": "8080"}).
+					WithPublish("8080").
+					WithPublishAll().
+					Execute(image.ID)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(container).Should(Serve(ContainSubstring("hello world")))
+
+				Expect(logs).To(ContainLines(
+					MatchRegexp(fmt.Sprintf(`%s%s \d+\.\d+\.\d+`, extenderBuildStrEscaped, settings.Buildpack.Name)),
+					extenderBuildStr+"  Using tini for process launching",
+					extenderBuildStr+"  Assigning launch processes:",
+					extenderBuildStr+"    web (default): tini -g -- node server.js",
+				))
+			})
+		})
 	})
 }

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -31,6 +31,9 @@ var settings struct {
 		Watchexec struct {
 			Online string
 		}
+		Tini struct {
+			Online string
+		}
 	}
 
 	Extensions struct {
@@ -48,6 +51,7 @@ var settings struct {
 		NodeEngine         string `json:"node-engine"`
 		NPMInstall         string `json:"npm-install"`
 		Watchexec          string `json:"watchexec"`
+		Tini               string `json:"tini"`
 		UbiNodejsExtension string `json:"ubi-nodejs-extension"`
 	}
 }
@@ -102,6 +106,10 @@ func TestIntegration(t *testing.T) {
 
 	settings.Buildpacks.Watchexec.Online, err = libpakBuildpackStore.Get.
 		Execute(settings.Config.Watchexec)
+	Expect(err).ToNot(HaveOccurred())
+
+	settings.Buildpacks.Tini.Online, err = buildpackStore.Get.
+		Execute(settings.Config.Tini)
 	Expect(err).ToNot(HaveOccurred())
 
 	suite := spec.New("Integration", spec.Report(report.Terminal{}), spec.Parallel())


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR:
* Introduces an env variable called `BP_LAUNCH_WITH_TINI` and when is set to true, it wraps the existing command with tini
* It allows running applications on top of tiny base run images
* Hanldes signal forwarding and processes reaping, as currently the application does not respond when a signal is being sent to the application due to `node` is not meant to do this, but only run the node application instead
* It does not overlap or alters the existing behaviour

## limitations
* It can not run more than one command e.g. `NODE_ENV=production node server.js` is not possible as `tini` does not support that

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
